### PR TITLE
Updated to Glowroot 0.13.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ To start up the server (for sake of the example `gserver`), on gserver, a machin
 `docker-compose` and access to `docker hub` just:
 
 ```bash
+export PASSWORD=admin
 docker-compose -f docker-compose.yml up
 ```
 
-### Exposd Ports
+### Exposed Ports
 
 The server setup will expose:
 
@@ -39,7 +40,7 @@ to target `http://gserver:4000` to get the the Growroot collector UI.
 This collector server, as it name implies, needs data to be pushed into it from applications. To
 push data to `gserver`'s collector you need to do the following:
 
- - Download the [glowroot distribution](https://github.com/glowroot/glowroot/releases/download/v0.10.9/glowroot-0.10.9-dist.zip)
+ - Download the [glowroot distribution](https://github.com/glowroot/glowroot/releases/download/v0.13.4/glowroot-0.13.4-dist.zip)
  and unpack it in a location accessible to the running app, for example `/opt/glowroot`.
  
  - You should now have `/opt/glowroot/` containing the distribution, is `/opt/glowroot/glowroot.jar` present?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,37 @@
-version: '3'
+version: "3.3"
+
 services:
   cassandra:
     container_name: cassandra
     image: cassandra:latest
-    volumes: 
-      - cassandra:/var/lib/cassandra
+    volumes:
+      - cassandra-data:/var/lib/cassandra
+    restart: always
     networks:
-      - glowroot_net
+      - monitoring
 
   glowroot:
     container_name: glowroot
-    image: seepen/glowroot-central
+    image: glowroot/glowroot-central:0.13.4
     ports:
       - "4000:4000"
       - "8181:8181"
+    expose:
+      - "4000"
+      - "8181"
+    depends_on:
+      - cassandra
+    restart: always
+    command: ["bash", "-c", "java -jar glowroot-central.jar setup-admin-user 'admin' '${PASSWORD}' && java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -jar glowroot-central.jar"]
     volumes:
       - ./glowroot-central.properties:/glowroot-central/glowroot-central.properties
     networks:
-      - glowroot_net
+      - monitoring
 
 volumes:
-  cassandra: {}
-  
-networks: 
-  glowroot_net:
-  
+  cassandra-data:
+
+networks:
+  monitoring:
+    external:
+      name: monitoring

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,13 @@
 version: "3.3"
-
 services:
   cassandra:
     container_name: cassandra
     image: cassandra:latest
     volumes:
-      - cassandra-data:/var/lib/cassandra
+      - cassandra:/var/lib/cassandra
     restart: always
     networks:
-      - monitoring
+      - glowroot_net
 
   glowroot:
     container_name: glowroot
@@ -26,12 +25,11 @@ services:
     volumes:
       - ./glowroot-central.properties:/glowroot-central/glowroot-central.properties
     networks:
-      - monitoring
+      - glowroot_net
 
 volumes:
-  cassandra-data:
-
-networks:
-  monitoring:
-    external:
-      name: monitoring
+  cassandra: {}
+  
+networks: 
+  glowroot_net:
+  


### PR DESCRIPTION
Hi,

I've updated docker compose file to use latest glowroot 0.13.4 (I've tried 0.13.6 but it contains error).

Docker compose file version has also been updated to 3.3. I have also removed use of ```link``` and replace it with ```depends_on``` as the former has been deprecated in favour of the latter.

Updated readme as well for specifying default password acquired from environment variable.